### PR TITLE
Move to node 18 alpine and npm package manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:14
+FROM node:18-alpine
 
 COPY . /usr/src/app
 
 WORKDIR /usr/src/app
 
-RUN yarn install --non-interactive --frozen-lockfile
+RUN npm ci
 
 COPY ./docker/entrypoint.sh /usr/local/bin
 


### PR DESCRIPTION
Got an error during the build with tests: 
```antlr4@4.13.0: The engine "node" is incompatible with this module. Expected version ">=16". Got "14.21.3"```

Updated Node to 18 LTS and picked Alpine distributive as a lightweight solution.